### PR TITLE
Add Google's ADK to Agent Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ A curated, list of 100+ libraries and frameworks for AI engineers building with 
 
 | Framework | Description | Language | License |
 |-----------|-------------|----------|---------|
+| [Google's ADK](https://google.github.io/adk-docs/) | Flexible and modular framework for developing and deploying AI agents | Python / Java | Apache-2.0 |
 | [AutoGen](https://github.com/microsoft/autogen) | Multi-agent conversation framework | Python | CC-BY-4.0 | 
 | [CrewAI](https://github.com/joaomdmoura/crewAI) | Framework for orchestrating role-playing autonomous AI agents | Python | MIT | 
 | [LangGraph](https://github.com/langchain-ai/langgraph) | Build resilient language agents as graphs | Python | MIT |


### PR DESCRIPTION
Google's ADK is gaining lot of ground as an alternative to other popular frameworks. This deserves a mention in the frameworks list.